### PR TITLE
Added highlighted boxes around posts/replies

### DIFF
--- a/UserGuide.md
+++ b/UserGuide.md
@@ -2,10 +2,10 @@
 
 ## Teacher/Student Indication
 
-- This new feature will automatically be applied to any posts or replies on the website. Depending on the account type of a user (student/instructor), there will be an indication written next to their username,
-as well as a colored text box surrounding their posts/replies. 
-- To user test this new feature, try creating new accounts of the student/instructor type, and making any post or reply
-- Additional automated tests, as well as improvements to existing tests can be found inside the test/user.js file
-- The two edited functions getUserData and getUserFields are tested in these tests
+- This new feature will automatically be applied to any posts or replies on the website. Depending on the account type of a user (student/instructor), there will be an indication written next to their username, as well as a colored text box surrounding their posts/replies. 
+- To user test this new feature, try creating new accounts of the student/instructor type, and making any post or reply. 
+- Additional automated tests, as well as improvements to existing tests can be found inside the test/user.js file. 
+- The two edited functions getUserData and getUserFields are tested in these tests. 
 - Two tests are added for getUserFields, to ensure the accounttype and isStudent fields are properly saved whenever a user is created, which was previously untested. 
-- Additional type checks are added for getUserData
+- Additional type checks are added for getUserData. 
+- These changes are sufficient for ensuring the necessary data is passed to the post.tpl file. 

--- a/UserGuide.md
+++ b/UserGuide.md
@@ -1,0 +1,11 @@
+#### How to use and test new features
+
+## Teacher/Student Indication
+
+- This new feature will automatically be applied to any posts or replies on the website. Depending on the account type of a user (student/instructor), there will be an indication written next to their username,
+as well as a colored text box surrounding their posts/replies. 
+- To user test this new feature, try creating new accounts of the student/instructor type, and making any post or reply
+- Additional automated tests, as well as improvements to existing tests can be found inside the test/user.js file
+- The two edited functions getUserData and getUserFields are tested in these tests
+- Two tests are added for getUserFields, to ensure the accounttype and isStudent fields are properly saved whenever a user is created, which was previously untested. 
+- Additional type checks are added for getUserData

--- a/public/openapi/components/schemas/Chats.yaml
+++ b/public/openapi/components/schemas/Chats.yaml
@@ -50,6 +50,9 @@ MessageObject:
           type: string
           description: An URL-safe variant of the username (i.e. lower-cased, spaces removed, etc.)
           example: dragon-fruit
+        isStudent:
+          type: boolean
+          description: True if user is student, false otherwise
         picture:
           type: string
           nullable: true
@@ -113,6 +116,9 @@ RoomUserList:
             type: string
           status:
             type: string
+          isStudent:
+            type: boolean
+            description: True if user is student, false otherwise
           displayname:
             type: string
             description: This is either username or fullname depending on forum and user settings
@@ -157,6 +163,9 @@ RoomObjectFull:
                 type: string
               status:
                 type: string
+              isStudent:
+                type: boolean
+                description: True if user is student, false otherwise
               displayname:
                 type: string
                 description: This is either username or fullname depending on forum and user settings

--- a/public/openapi/components/schemas/FlagObject.yaml
+++ b/public/openapi/components/schemas/FlagObject.yaml
@@ -117,6 +117,9 @@ FlagHistoryObject:
                 type: string
                 description: An URL-safe variant of the username (i.e. lower-cased, spaces
                   removed, etc.)
+              isStudent:
+                type: boolean
+                description: True if user is student, false otherwise
               picture:
                 nullable: true
               uid:
@@ -165,6 +168,9 @@ FlagNotesObject:
                 type: string
                 description: An URL-safe variant of the username (i.e. lower-cased, spaces
                   removed, etc.)
+              isStudent:
+                type: boolean
+                description: True if user is student, false otherwise
               picture:
                 type: string
               uid:

--- a/public/openapi/components/schemas/PostObject.yaml
+++ b/public/openapi/components/schemas/PostObject.yaml
@@ -41,6 +41,9 @@ PostObject:
           type: string
           description: An URL-safe variant of the username (i.e. lower-cased, spaces
             removed, etc.)
+        isStudent:
+          type: boolean
+          description: True if user is student, false otherwise
         picture:
           type: string
           nullable: true

--- a/public/openapi/components/schemas/TopicObject.yaml
+++ b/public/openapi/components/schemas/TopicObject.yaml
@@ -59,6 +59,8 @@ TopicObject:
               nullable: true
             banned:
               type: number
+            isStudent:
+              type: boolean
             status:
               type: string
             icon:text:

--- a/public/openapi/components/schemas/UserObj.yaml
+++ b/public/openapi/components/schemas/UserObj.yaml
@@ -121,3 +121,7 @@ UserObj:
     banned_until_readable:
       type: string
       example: Not Banned
+    isStudent:
+      type: boolean
+      description: True if user is student, false otherwise
+      example: True

--- a/public/openapi/components/schemas/UserObject.yaml
+++ b/public/openapi/components/schemas/UserObject.yaml
@@ -29,6 +29,10 @@ UserObject:
       type: string
       description: Type of the user account
       example: student
+    isStudent:
+      type: boolean
+      description: True if user is student, false otherwise
+      example: True
     lastonline:
       type: number
       description: A UNIX timestamp representing the moment the user was last recorded online on this site
@@ -228,6 +232,10 @@ UserObjectFull:
       type: string
       description: Type of the user account
       example: student
+    isStudent:
+      type: boolean
+      description: True if user is student, false otherwise
+      example: True
     lastonline:
       type: number
       description: A UNIX timestamp representing the moment the user was last recorded online on this site
@@ -569,6 +577,10 @@ UserObjectSlim:
       type: string
       description: Type of the user account
       example: student
+    isStudent:
+      type: boolean
+      description: True if user is student, false otherwise
+      example: True
     'icon:text':
       type: string
       description: A single-letter representation of a username. This is used in the auto-generated icon given to users without an avatar
@@ -625,6 +637,10 @@ UserObjectACP:
       type: string
       description: Type of the user account
       example: student
+    isStudent:
+      type: boolean
+      description: True if user is student, false otherwise
+      example: True
     banned:
       type: number
       description: A Boolean representing whether a user is banned or not

--- a/src/posts/user.js
+++ b/src/posts/user.js
@@ -111,7 +111,7 @@ module.exports = function (Posts) {
         assert.equal(typeof (uid), 'number');
 
         const fields = [
-            'uid', 'username', 'fullname', 'accounttype', 'userslug',
+            'uid', 'username', 'fullname', 'accounttype', 'isStudent', 'userslug',
             'reputation', 'postcount', 'topiccount', 'picture',
             'signature', 'banned', 'banned:expire', 'status',
             'lastonline', 'groupTitle', 'mutedUntil',

--- a/src/user/data.js
+++ b/src/user/data.js
@@ -20,7 +20,7 @@ const intFields = [
 
 module.exports = function (User) {
     const fieldWhitelist = [
-        'uid', 'username', 'userslug', 'email', 'email:confirmed', 'joindate', 'accounttype',
+        'uid', 'username', 'userslug', 'email', 'email:confirmed', 'joindate', 'accounttype', 'isStudent',
         'lastonline', 'picture', 'icon:bgColor', 'fullname', 'location', 'birthday', 'website',
         'aboutme', 'signature', 'uploadedpicture', 'profileviews', 'reputation',
         'postcount', 'topiccount', 'lastposttime', 'banned', 'banned:expire',
@@ -78,6 +78,7 @@ module.exports = function (User) {
             if (uniqueUids[index] > 0 && !user.uid) {
                 user.oldUid = uniqueUids[index];
             }
+            user.isStudent = user.accounttype === 'student';
         });
         await modifyUserData(result.users, fields, fieldsToRemove);
         return uidsToUsers(uids, uniqueUids, result.users);

--- a/src/user/data.js
+++ b/src/user/data.js
@@ -52,8 +52,8 @@ module.exports = function (User) {
             return [];
         }
         // Asserting function parameter types
-        //uids and fields are both arrays that have items that can take on multiple types
-        //so there is no way to write asserts for them
+        // uids and fields are both arrays that have items that can take on multiple types
+        // so there is no way to write asserts for them
         assert.equal(typeof (uids), 'object');
         assert.equal(typeof (fields), 'object');
 

--- a/src/user/data.js
+++ b/src/user/data.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const assert = require('assert');
 const validator = require('validator');
 const nconf = require('nconf');
 const _ = require('lodash');
@@ -44,10 +45,17 @@ module.exports = function (User) {
         'email:confirmed': 0,
     };
 
+    // Type signature: async function getUserFields(uids: Array<string>,
+    //                                              fields: Array<string>) => Array<UserData>
     User.getUsersFields = async function (uids, fields) {
         if (!Array.isArray(uids) || !uids.length) {
             return [];
         }
+        // Asserting function parameter types
+        //uids and fields are both arrays that have items that can take on multiple types
+        //so there is no way to write asserts for them
+        assert.equal(typeof (uids), 'object');
+        assert.equal(typeof (fields), 'object');
 
         uids = uids.map(uid => (isNaN(uid) ? 0 : parseInt(uid, 10)));
 

--- a/test/user.js
+++ b/test/user.js
@@ -83,7 +83,7 @@ describe('User', () => {
 
         it('should be created properly', async () => {
             const email = '<h1>test</h1>@gmail.com';
-            const uid = await User.create({ username: 'weirdemail', email: email});
+            const uid = await User.create({ username: 'weirdemail', email: email });
             const data = await User.getUserData(uid);
 
             const validationPending = await User.email.isValidationPending(uid, email);
@@ -158,21 +158,21 @@ describe('User', () => {
 
         it('should create student account properly', async () => {
             const email = '<h1>test</h1>@gmail.com';
-            const uid = await User.create({ username: 'weirdemail', email: email, accounttype: 'student'});
+            const uid = await User.create({ username: 'weirdemail', email: email, accounttype: 'student' });
             const userData = await User.getUsersFields([uid], ['accounttype', 'isStudent']);
             // make sure accounttype is stored
             assert.equal(userData[0].accounttype, 'student');
-            //make sure isStudent is set
+            // make sure isStudent is set
             assert.equal(userData[0].isStudent, true);
         });
 
         it('should create instructor account properly', async () => {
             const email = '<h1>test</h1>@gmail.com';
-            const uid = await User.create({ username: 'weirdemail', email: email, accounttype: 'instructor'});
+            const uid = await User.create({ username: 'weirdemail', email: email, accounttype: 'instructor' });
             const userData = await User.getUsersFields([uid], ['accounttype', 'isStudent']);
             // make sure accounttype is stored
             assert.equal(userData[0].accounttype, 'instructor');
-            //make sure isStudent is set peroperly
+            // make sure isStudent is set peroperly
             assert.equal(userData[0].isStudent, false);
         });
 

--- a/test/user.js
+++ b/test/user.js
@@ -83,7 +83,7 @@ describe('User', () => {
 
         it('should be created properly', async () => {
             const email = '<h1>test</h1>@gmail.com';
-            const uid = await User.create({ username: 'weirdemail', email: email });
+            const uid = await User.create({ username: 'weirdemail', email: email});
             const data = await User.getUserData(uid);
 
             const validationPending = await User.email.isValidationPending(uid, email);
@@ -154,6 +154,26 @@ describe('User', () => {
                 assert.equal(userNames.filter(username => username === 'dupe1').length, 1);
                 assert.equal(userNames.filter(username => username === 'dupe1 0').length, 1);
             }
+        });
+
+        it('should create student account properly', async () => {
+            const email = '<h1>test</h1>@gmail.com';
+            const uid = await User.create({ username: 'weirdemail', email: email, accounttype: 'student'});
+            const userData = await User.getUsersFields([uid], ['accounttype', 'isStudent']);
+            // make sure accounttype is stored
+            assert.equal(userData[0].accounttype, 'student');
+            //make sure isStudent is set
+            assert.equal(userData[0].isStudent, true);
+        });
+
+        it('should create instructor account properly', async () => {
+            const email = '<h1>test</h1>@gmail.com';
+            const uid = await User.create({ username: 'weirdemail', email: email, accounttype: 'instructor'});
+            const userData = await User.getUsersFields([uid], ['accounttype', 'isStudent']);
+            // make sure accounttype is stored
+            assert.equal(userData[0].accounttype, 'instructor');
+            //make sure isStudent is set peroperly
+            assert.equal(userData[0].isStudent, false);
         });
 
         it('should error if email is already taken', async () => {

--- a/themes/nodebb-theme-persona/less/topic.less
+++ b/themes/nodebb-theme-persona/less/topic.less
@@ -152,6 +152,30 @@
 		position: relative;
 		top: -@post-padding;
 	}
+	
+	[component="post/teacher-content"] {
+		border-radius: 25px;
+		border-style: solid;
+		border-width: 3px;
+    	border-left-width: 3px;
+    	border-right-width: 3px;
+    	border-color: rgb(238, 213, 113);
+    	padding: 10px; 
+    	margin-bottom: 40px; 
+		content: "\f11c";
+	}
+
+	[component="post/student-content"] {
+		border-radius: 25px;
+		border-style: solid;
+		border-width: 3px;
+    	border-left-width: 3px;
+    	border-right-width: 3px;
+    	border-color: lightgreen;
+    	padding: 10px; /* Adjust padding as needed */
+    	margin-bottom: 40px; 
+		content: "\f11c";
+	}
 
 	[component="post/upvote"], [component="post/downvote"] {
 		color: @gray-light;

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -49,9 +49,17 @@
 
 <br />
 
-<div class="content" component="post/content" itemprop="text">
-    {posts.content}
-</div>
+<!-- IF posts.user.isStudent-->
+    <div class="content" component="post/student-content" itemprop="text">
+        {posts.content}
+    </div>
+<!-- ENDIF posts.user.isStudent-->
+
+<!-- IF !posts.user.isStudent-->
+    <div class="content" component="post/teacher-content" itemprop="text">
+        {posts.content}
+    </div>
+<!-- ENDIF !posts.user.isStudent-->
 
 <div class="post-footer">
     {{{ if posts.user.signature }}}


### PR DESCRIPTION
Resolves #7 and #14 

- Edited text boxes around student and instructor replies to change color based on if a student or instructor posted
- Edited getUserData function in src/posts/user.js to grab if an account is a student
- Made frontend changes in post.tpl to change appearance of posts using the newly created isStudent field
- Added isStudent to relevant schemas
- Added assertions and comments for typechecking
- Added unit tests to test changes to getUserData and getUserFields functions
- Passed linter and testing suite

Original behavior:
![image](https://github.com/CMU-313/spring24-nodebb-team-3/assets/67977275/52964068-d083-4989-9e11-0efe2d4425d5)

New behavior:
<img width="1196" alt="image" src="https://github.com/CMU-313/spring24-nodebb-team-3/assets/67977275/ab7bb297-3ecc-490a-93fd-52f0e3deb957">
