### PR TITLE
Added feature making votes from original poster weigh more

### DIFF
--- a/src/posts/votes.js
+++ b/src/posts/votes.js
@@ -168,6 +168,11 @@ module.exports = function (Posts) {
     }
 
     async function vote(type, unvote, pid, uid, voteStatus) {
+        console.assert(typeof type === 'string');
+        console.assert(typeof unvote === 'boolean');
+        console.assert(typeof pid === 'number');
+        console.assert(typeof uid === 'number');
+        console.assert(typeof voteStatus === 'object');
         uid = parseInt(uid, 10);
         if (uid <= 0) {
             throw new Error('[[error:not-logged-in]]');
@@ -188,7 +193,7 @@ module.exports = function (Posts) {
 
         const postData = await Posts.getPostFields(pid, ['pid', 'uid', 'tid', 'toPid', 'upvotes']);
         const parentPostData = await Posts.getPostFields(postData.toPid, ['uid']);
-        let jmp = parentPostData.uid == uid ? 5 : 1;
+        const jmp = parentPostData.uid === uid ? 5 : 1;
         const newReputation = await user.incrementUserReputationBy(postData.uid, type === 'upvote' ? jmp : -jmp);
 
         await adjustPostVotes(postData, uid, type, unvote);

--- a/src/posts/votes.js
+++ b/src/posts/votes.js
@@ -186,8 +186,10 @@ module.exports = function (Posts) {
             await db.sortedSetAdd(`uid:${uid}:downvote`, now, pid);
         }
 
-        const postData = await Posts.getPostFields(pid, ['pid', 'uid', 'tid']);
-        const newReputation = await user.incrementUserReputationBy(postData.uid, type === 'upvote' ? 1 : -1);
+        const postData = await Posts.getPostFields(pid, ['pid', 'uid', 'tid', 'toPid', 'upvotes']);
+        const parentPostData = await Posts.getPostFields(postData.toPid, ['uid']);
+        let jmp = parentPostData.uid == uid ? 5 : 1;
+        const newReputation = await user.incrementUserReputationBy(postData.uid, type === 'upvote' ? jmp : -jmp);
 
         await adjustPostVotes(postData, uid, type, unvote);
 


### PR DESCRIPTION
Resolves #22
- Edited the way voting increments or decrements the reputation of the poster of the post being voted on
- Edited functionality of the vote function to retrieve the post ID of the post that's being replied to
- Used Posts method to retrieve the user ID of the post being replied to
- Created conditional logic to check whether the current user matches the user of the post being replied to
- Changed reputation update code to update by 5 instead of 1 if the user matches
- Added assertions for type checking
- Added unit tests to test the retrieval of key post fields
- Passed linter and testing suite

Original behavior:
![image](https://github.com/CMU-313/spring24-nodebb-team-3/assets/127244212/e8f92acd-60c6-41f9-9795-84bcfc8438ac)
![image](https://github.com/CMU-313/spring24-nodebb-team-3/assets/127244212/f74b7698-1d58-4e45-b3b5-ca05a7b00569)
![image](https://github.com/CMU-313/spring24-nodebb-team-3/assets/127244212/d26f41a0-87a3-4f47-a798-1c4f64de30ea)

New behavior:
![image](https://github.com/CMU-313/spring24-nodebb-team-3/assets/127244212/e8f92acd-60c6-41f9-9795-84bcfc8438ac)
![image](https://github.com/CMU-313/spring24-nodebb-team-3/assets/127244212/f74b7698-1d58-4e45-b3b5-ca05a7b00569)
![image](https://github.com/CMU-313/spring24-nodebb-team-3/assets/127244212/cf7e26ec-0783-4d06-8f7d-ce3c0e46adb0)
