### PR TITLE
empty change so that the dead gcp instance won't automatically fail the build github action

### DIFF
--- a/install/databases.js
+++ b/install/databases.js
@@ -52,7 +52,6 @@ function saveDatabaseConfig(config, databaseConfig) {
             password: databaseConfig['redis:password'],
             database: databaseConfig['redis:database'],
         };
-
         if (config.redis.host.slice(0, 1) === '/') {
             delete config.redis.port;
         }


### PR DESCRIPTION
- testing so that all tests pass
- got rid of old gcp instance because we have working new one in effect